### PR TITLE
Removed unnecessary initialization from elasticsearch statefulsets

### DIFF
--- a/app/crowi.yml
+++ b/app/crowi.yml
@@ -109,17 +109,6 @@ spec:
             requests:
               cpu: "200m"
               memory: "0.1Gi"
-      initContainers:
-        - image: alpine:3.6
-          command: ["/sbin/sysctl", "-w", "vm.max_map_count=262144"]
-          name: elasticsearch-init-vm-map-count
-          securityContext:
-            privileged: true
-        - image: alpine:3.6
-          command: ["sh", "-c", "ulimit -n -1"]
-          name: elasticsearch-init-ulimit
-          securityContext:
-            privileged: true
   volumeClaimTemplates:
     - metadata:
         name: elasticsearch-pvc


### PR DESCRIPTION
なんかinitcontainerとか使わなくてもelasticsearch行けたわ。何をやっていたんだろうか。